### PR TITLE
Pre commit integration

### DIFF
--- a/Pixel Soup/.pre-commit-config.yaml
+++ b/Pixel Soup/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+default_language_version:
+  python: python3.7
+
+repos:
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8

--- a/Pixel Soup/.pre-commit-config.yaml
+++ b/Pixel Soup/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
+
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black

--- a/Pixel Soup/README.md
+++ b/Pixel Soup/README.md
@@ -1,0 +1,1 @@
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/Pixel Soup/README.md
+++ b/Pixel Soup/README.md
@@ -1,1 +1,2 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)

--- a/Pixel Soup/setup.cfg
+++ b/Pixel Soup/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
This adds a pre-commit hook to avoid inserting changes that do not pass the black and flake8 checks. As it is integrated into pipenv, to install it just run into the project's directory:

```
pipenv run pre-commit install
```

And that's all!